### PR TITLE
RDK-57171: Add L1 test cases for coverity fixes

### DIFF
--- a/cov_build.sh
+++ b/cov_build.sh
@@ -1,3 +1,21 @@
+#
+## Copyright 2023 Comcast Cable Communications Management, LLC
+##
+## Licensed under the Apache License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+## http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+##
+## SPDX-License-Identifier: Apache-2.0
+#
+
 WORKDIR=`pwd`
 
 ## Build and install critical dependency

--- a/include/rdm_download.h
+++ b/include/rdm_download.h
@@ -45,5 +45,6 @@ INT32 rdmDownloadApp(RDMAPPDetails *pRdmAppDet, INT32 *pDLStatus);
 INT32 rdmDownloadVerApp(RDMAPPDetails *pRdmAppDet);
 INT32 rdmDownloadMgr(RDMAPPDetails *pRdmAppDet);
 INT32 rdmPackageMgr(RDMAPPDetails *pRdmAppDet);
+INT32 rdmDwnlExtract(RDMAPPDetails *pRdmAppDet);
 
 #endif //_RDM_DOWNLOAD_H_

--- a/include/rdm_downloadutils.h
+++ b/include/rdm_downloadutils.h
@@ -19,6 +19,10 @@
 #ifndef _RDM_DOWNLOADUTILS_H_
 #define _RDM_DOWNLOADUTILS_H_
 
+#ifdef GTEST_ENABLE
+#include "../unittest/mocks/system_utils.h"
+#endif
+
 //Define required file paths here
 #define RDM_DWNL_URL            "/path/to/my/url/file"
 #define RDM_DWNLSSR_URL         "/path/to/my/url/file"
@@ -59,6 +63,10 @@ INT32  rdmDwnlIsOCSPEnable(void);
 INT32  rdmDwnlCreateFolder(CHAR *pAppPath, CHAR *pAppname);
 VOID   rdmDwnlCleanUp(CHAR *pDwnlPath);
 VOID   rdmDwnlAppCleanUp(CHAR *pAppPath);
+#ifdef GTEST_ENABLE
+INT32  rdmDwnlGetCert(MtlsAuth_t*);
+INT32  rdmDwnlUpdateManifest(CHAR *pInManifest, CHAR *pOutManifest, CHAR *update, CHAR *padding);
+#endif
 VOID   rdmRemvDwnlAppInfo(CHAR *pAppName, CHAR *pDwnlInfoFile);
 INT32  rdmDwnlRunPostScripts(CHAR *pAppHome);
 UINT32 rdmDwnlIsBlocked(CHAR *file, INT32 block_time);
@@ -67,6 +75,7 @@ INT32  rdmJRPCTokenData(CHAR *token,CHAR *pJsonStr,UINT32 token_size);
 INT32  rdmMemDLAlloc(VOID *pDwnData, size_t szDataSize);
 VOID   rdmMemDLFree(VOID *pvDwnData);
 INT32  rdmDwnlValidation(RDMAPPDetails *pRdmAppDet, CHAR *pVer);
+INT32  rdmDwnlDirect(CHAR* pUrl, CHAR* pDwnlPath, CHAR* pPkgName, CHAR* pOut, INT32 isMtls);
 INT32 rdmUnInstallApps(INT32 is_broadband );
 INT32 rdmGetManifestApps(CHAR **pAppsInManifest, INT32 *numOfApps);
 INT32 rdmUpdateAppDetails(RDMHandle *prdmHandle,

--- a/include/rdm_openssl.h
+++ b/include/rdm_openssl.h
@@ -69,4 +69,6 @@ INT32 rdmDecryptKey(CHAR *out_key);
 
 VOID rdmInitSslLib(VOID);
 
+void dump_buffer(void *buffer, INT32 buffer_size, CHAR *name);
+
 #endif //_RDM_TYPES_H_

--- a/src/rdm_downloadmgr.c
+++ b/src/rdm_downloadmgr.c
@@ -16,7 +16,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "rdmMgr.h"
 #include "rdm_types.h"
 #include "rdm.h"
 #include "rdm_utils.h"
@@ -24,7 +23,13 @@
 #include "rdm_download.h"
 #include "rdm_openssl.h"
 #include "rdm_downloadutils.h"
+#ifndef GTEST_ENABLE
 #include <system_utils.h>
+#include "rdmMgr.h"
+#else
+#include "unittest/mocks/system_utils.h"
+#include "unittest/mocks/rdmMgr.h"
+#endif
 
 static INT32 rdmDownlLXCCheck(CHAR *package, CHAR *appname)
 {
@@ -170,7 +175,7 @@ INT32 rdmDwnlExtract(RDMAPPDetails *pRdmAppDet)
                     is_lxc = 1;
                 }
 
-                status = arExtract(tmp_file, pRdmAppDet->app_dwnl_path);
+                status = tarExtract(tmp_file, pRdmAppDet->app_dwnl_path);
                 if(status) {
                     rdmIARMEvntSendPayload(pRdmAppDet->pkg_name,
                                            pRdmAppDet->pkg_ver,

--- a/src/rdm_downloadutils.c
+++ b/src/rdm_downloadutils.c
@@ -23,12 +23,16 @@
 #include <time.h>
 #include <fcntl.h>
 #include <stdbool.h>
+#ifndef GTEST_ENABLE
 #include <system_utils.h>
 #include <json_parse.h>
 #include <downloadUtil.h>
 #include "codebigUtils.h"
 #include "rdmMgr.h"
-
+#else
+#include "unittest/mocks/system_utils.h"
+#include "unittest/mocks/rdmMgr.h"
+#endif
 
 #include "rdm_types.h"
 #include "rdm.h"
@@ -474,7 +478,7 @@ INT32 rdmDwnlUpdateManifest(CHAR *pInManifest,
     FILE *fpin;
     FILE *fpout;
     INT32 status = RDM_SUCCESS;
-    CHAR *buff;
+    CHAR *buff = NULL;
 
     fpin = fopen(pInManifest, "r");
     if(fpin == NULL) {
@@ -483,7 +487,7 @@ INT32 rdmDwnlUpdateManifest(CHAR *pInManifest,
     }
 
     fpout = fopen(pOutManifest, "w");
-    if(fpin == NULL) {
+    if(fpout == NULL) {
         RDMError("Unable to open output file: %s\n", pOutManifest);
         status = RDM_FAILURE;
         goto error;

--- a/src/rdm_downloadverapp.c
+++ b/src/rdm_downloadverapp.c
@@ -23,7 +23,11 @@
 #include "rdm_download.h"
 #include "rdm_downloadutils.h"
 #include "rdm_downloadverapp.h"
+#ifndef GTEST_ENABLE
 #include <system_utils.h>
+#else
+#include "unittest/mocks/system_utils.h"
+#endif
 
 static INT32 rdmDwnlVAVerifyApp(RDMAPPDetails *pRdmAppDet, CHAR *pVer)
 {

--- a/src/rdm_jsonquery.c
+++ b/src/rdm_jsonquery.c
@@ -186,6 +186,7 @@ INT32 rdmJSONGetLen(CHAR const* pfName,
 
     cJSON* item = NULL;
 
+    RDMInfo("Manifest: %s\n", pfName);
     if (!pfName) {
         RDMError("Invalid file name\n");
         return RDM_FAILURE;

--- a/src/rdm_openssl.c
+++ b/src/rdm_openssl.c
@@ -31,8 +31,13 @@
 #include "rdm.h"
 #include "rdm_utils.h"
 #include "rdm_openssl.h"
+#ifndef GTEST_ENABLE
 #include <system_utils.h>
 #include <secure_wrapper.h>
+#else
+#include "unittest/mocks/system_utils.h"
+#include "unittest/mocks/secure_wrapper.h"
+#endif
 #ifdef LIBRDKCONFIG_BUILD
 #include "rdkconfig.h"
 #endif

--- a/src/rdm_rbus.c
+++ b/src/rdm_rbus.c
@@ -29,11 +29,16 @@
 #include <unistd.h>
 #include <signal.h>
 
+#ifndef GTEST_ENABLE
 #include "rbus.h"
 #include "rdm_types.h"
-#include "rdm.h"
 #include "rdm_rbus.h"
 #include "rdm_utils.h"
+#else
+#include "unittest/mocks/mock_rdm_rbustypes.h"
+#endif
+#include "rdm.h"
+
 /** @brief This Function initializes rbus.
  *
  *  @param[in/out]  ppRDMRbusHandle  rbus handle

--- a/unit_test.sh
+++ b/unit_test.sh
@@ -1,4 +1,23 @@
 #!/bin/bash
+
+#
+## Copyright 2023 Comcast Cable Communications Management, LLC
+##
+## Licensed under the Apache License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+## http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+##
+## SPDX-License-Identifier: Apache-2.0
+#
+
 cd unittest/
 
 automake --add-missing
@@ -27,13 +46,24 @@ echo "*********** Return value of json_gtest $rdmjson"
 
 ./rdm_download_gtest
 rdmdown=$?
-echo "*********** Return value of rdm_utils_gtest $rdmdown"
+echo "*********** Return value of rdm_download_gtest $rdmdown"
 
+./rdm_downloadutils_gtest
+rdmdutils=$?
+echo "*********** Return value of rdm_downloadutils_gtest $rdmdutils"
+
+./rdm_rbus_gtest
+rdmrbus=$?
+echo "*********** Return value of rdm_rbus_gtest $rdmrbus"
+
+./rdm_openssl_gtest
+rdmopenssl=$?
+echo "*********** Return value of rdm_openssl_gtest $rdmopenssl"
 
 # List of unit test executables
 
 # Run tests and capture return values
-if [ "$rdmmain" = "0" ] && [ "$utils" = "0" ] && [ "$rdmcurl" = "0" ] && [ "$rdmjson" = "0" ] && [ "$rdmdown" = "0" ] ; then
+if [ "$rdmmain" = "0" ] && [ "$utils" = "0" ] && [ "$rdmcurl" = "0" ] && [ "$rdmjson" = "0" ] && [ "$rdmdown" = "0" ] && [ "$rdmdutils" = "0" ] && [ "$rdmrbus" = "0" ] && [ "$rdmopenssl" = "0" ]; then
     cd ../
 
     lcov --capture --directory . --output-file coverage.info

--- a/unittest/Makefile.am
+++ b/unittest/Makefile.am
@@ -1,9 +1,27 @@
+#
+## Copyright 2023 Comcast Cable Communications Management, LLC
+##
+## Licensed under the Apache License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+## http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+##
+## SPDX-License-Identifier: Apache-2.0
+#
+
 AUTOMAKE_OPTIONS = subdir-objects 
 ACLOCAL_AMFLAGS = -I m4
 
 # Define the test executables
 bin_PROGRAMS = rdm_main_gtest rdm_curl_gtest rdm_utils_gtest rdm_json_gtest \
-               rdm_download_gtest 
+               rdm_download_gtest rdm_downloadutils_gtest rdm_rbus_gtest rdm_openssl_gtest
 
 # Common include directories
 COMMON_CPPFLAGS = -std=c++11 -I/usr/include/cjson -I./include  -I../ -I../../ -I/usr/include -I../include -I../mocks -I../src -I../include    \
@@ -14,7 +32,7 @@ AM_CPPFLAGS =  -I$(top_srcdir)/unittest/mocks -I$(top_srcdir)/include -I$(top_sr
 
 # Common libraries
 COMMON_LDADD = -lgtest -lgtest_main -lgmock -lgmock_main \
-               -lpthread -lcurl -lcjson
+               -lpthread -lcurl -lcjson -lssl -lcrypto
 
 # Common compiler flags
 COMMON_CXXFLAGS = -frtti -fprofile-arcs -ftest-coverage -fpermissive
@@ -24,9 +42,10 @@ rdm_main_gtest_SOURCES = rdm_main_gtest.cpp ../rdm_main.c
 rdm_curl_gtest_SOURCES = rdm_curl_gtest.cpp  ../src/rdm_curldownload.c
 rdm_utils_gtest_SOURCES = rdm_utils_gtest.cpp mocks/mock_iarm_bus.cpp  ../src/rdm_utils.c
 rdm_json_gtest_SOURCES = rdm_json_gtest.cpp ../src/rdm_jsonquery.c
-rdm_download_gtest_SOURCES = rdm_download_gtest.cpp ../src/rdm_download.c
-
-
+rdm_download_gtest_SOURCES = rdm_download_gtest.cpp mocks/mock_iarm_bus.cpp ../src/rdm_download.c ../src/rdm_downloadmgr.c ../src/rdm_utils.c ../src/rdm_downloadutils.c ../src/rdm_rbus.c ../src/rdm_jsonquery.c ../src/rdm_downloadverapp.c
+rdm_downloadutils_gtest_SOURCES = rdm_downloadutils_gtest.cpp mocks/mock_iarm_bus.cpp ../src/rdm_downloadutils.c ../src/rdm_rbus.c ../src/rdm_utils.c
+rdm_rbus_gtest_SOURCES = rdm_rbus_gtest.cpp ../src/rdm_rbus.c
+rdm_openssl_gtest_SOURCES = rdm_openssl_gtest.cpp ../src/rdm_openssl.c
 
 rdm_main_gtest_CPPFLAGS = $(COMMON_CPPFLAGS)
 rdm_main_gtest_LDADD = $(COMMON_LDADD)
@@ -54,4 +73,17 @@ rdm_download_gtest_LDADD = $(COMMON_LDADD)
 rdm_download_gtest_CXXFLAGS = $(COMMON_CXXFLAGS)
 rdm_download_gtest_CFLAGS = $(COMMON_CXXFLAGS)
 
+rdm_downloadutils_gtest_CPPFLAGS = $(COMMON_CPPFLAGS)
+rdm_downloadutils_gtest_LDADD = $(COMMON_LDADD)
+rdm_downloadutils_gtest_CXXFLAGS = $(COMMON_CXXFLAGS)
+rdm_downloadutils_gtest_CFLAGS = $(COMMON_CXXFLAGS)
 
+rdm_rbus_gtest_CPPFLAGS = $(COMMON_CPPFLAGS)
+rdm_rbus_gtest_LDADD = $(COMMON_LDADD)
+rdm_rbus_gtest_CXXFLAGS = $(COMMON_CXXFLAGS)
+rdm_rbus_gtest_CFLAGS = $(COMMON_CXXFLAGS)
+
+rdm_openssl_gtest_CPPFLAGS = $(COMMON_CPPFLAGS)
+rdm_openssl_gtest_LDADD = $(COMMON_LDADD)
+rdm_openssl_gtest_CXXFLAGS = $(COMMON_CXXFLAGS)
+rdm_openssl_gtest_CFLAGS = $(COMMON_CXXFLAGS)

--- a/unittest/configure.ac
+++ b/unittest/configure.ac
@@ -1,3 +1,21 @@
+#
+## Copyright 2023 Comcast Cable Communications Management, LLC
+##
+## Licensed under the Apache License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+## http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+##
+## SPDX-License-Identifier: Apache-2.0
+#
+
 # Initialize Autoconf
 AC_INIT([rdm_main_gtest], [1.0])
 AC_CONFIG_MACRO_DIRS([m4])

--- a/unittest/mocks/mock_curl.h
+++ b/unittest/mocks/mock_curl.h
@@ -1,3 +1,21 @@
+/**
+ * Copyright 2023 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 #ifndef MOCK_CURL_H
 #define MOCK_CURL_H
 

--- a/unittest/mocks/mock_iarm_bus.cpp
+++ b/unittest/mocks/mock_iarm_bus.cpp
@@ -1,3 +1,21 @@
+/**
+ * Copyright 2023 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 #include "unittest/mocks/mock_iarm_bus.h"
 #include <gmock/gmock.h>// Include Google Mock
 

--- a/unittest/mocks/mock_rdm_downloadutils.h
+++ b/unittest/mocks/mock_rdm_downloadutils.h
@@ -1,3 +1,21 @@
+/**
+ * Copyright 2023 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 #ifndef MOCK_RDM_DOWNLOADUTILS_H
 #define MOCK_RDM_DOWNLOADUTILS_H
 
@@ -12,9 +30,7 @@ extern "C" {
 
 class MockRdmDownloadUtils {
 public:
-        MOCK_METHOD1(rdmDownloadMgr, int(RDMAPPDetails*));
-        MOCK_METHOD2(rdmDwnlUnInstallApp, void(const char*, const char*));
-        MOCK_METHOD1(rdmDownloadVerApp, int(RDMAPPDetails*));
+    // Define any mock functions here
 };
 
 #endif // MOCK_RDM_DOWNLOADUTILS_H

--- a/unittest/mocks/mock_rdm_rbus.h
+++ b/unittest/mocks/mock_rdm_rbus.h
@@ -16,23 +16,23 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#ifndef MOCK_IARM_BUS_H
-#define MOCK_IARM_BUS_H
+#ifndef MOCK_RDM_RBUS_H
+#define MOCK_RDM_RBUS_H
 
 #include <gmock/gmock.h>
-#include "rdm_types.h" // Ensure this header includes the definition for IARM_Result_t and other types
+#include "mock_rdm_rbustypes.h"
 
-extern "C" {
-    #include "mocks/libIBus.h"
-}
-
-class MockIARM {
+class MockRdmRbus {
 public:
-    MOCK_METHOD(IARM_Result_t, IARM_Bus_Init, (const char*), ());
-    MOCK_METHOD(IARM_Result_t, IARM_Bus_Connect, (), ());
-    MOCK_METHOD0(IARM_Bus_Disconnect, IARM_Result_t());
-    MOCK_METHOD0(IARM_Bus_Term, IARM_Result_t());
-    MOCK_METHOD(IARM_Result_t, IARM_Bus_BroadcastEvent, (const char*, IARM_EventId_t, void*, size_t), ());
+    MOCK_METHOD(rbusValueType_t, rbusValue_GetType, (void*), ());
+    MOCK_METHOD(INT32, rbus_get, (void*, INT8*, void*), ());
+    MOCK_METHOD(const INT8*, rbusValue_ToString, (void*, void*, int), ());
+    MOCK_METHOD(bool, rbusValue_GetBoolean, (void*), ());
+    MOCK_METHOD(void, rbusValue_Release, (void*), ());
+    MOCK_METHOD(INT32, rbus_checkStatus, (), ());
+    MOCK_METHOD(INT32, rbus_open, (void*, INT8*), ());
+    MOCK_METHOD(INT32, rbus_close, (void*), ());
 };
 
-#endif // MOCK_IARM_BUS_H
+#endif // MOCK_RDM_RBUS_H
+

--- a/unittest/mocks/mock_rdm_rbustypes.h
+++ b/unittest/mocks/mock_rdm_rbustypes.h
@@ -1,0 +1,50 @@
+/**
+ * Copyright 2023 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include <stdint.h>
+#include "rdm_types.h"
+#include "rdm_utils.h"
+#include "rdm_rbus.h"
+
+#define RBUS_ERROR_SUCCESS 0
+#define RBUS_ENABLED 1
+typedef enum
+{
+    RBUS_BOOLEAN  = 0x500,  /**< bool true or false */
+    RBUS_CHAR,              /**< char of size 1 byte*/
+    RBUS_BYTE,              /**< unsigned char */
+    RBUS_INT8,              /**< 8 bit int */
+    RBUS_UINT8,             /**< 8 bit unsigned int */
+    RBUS_INT16,             /**< 16 bit int */
+    RBUS_UINT16,            /**< 16 bit unsigned int */
+    RBUS_INT32,             /**< 32 bit int */
+    RBUS_UINT32,            /**< 32 bit unsigned int */
+    RBUS_INT64,             /**< 64 bit int */
+    RBUS_UINT64,            /**< 64 bit unsigned int */
+    RBUS_SINGLE,            /**< 32 bit float */
+    RBUS_DOUBLE,            /**< 64 bit float */
+    RBUS_DATETIME,          /**< rbusDateTime_t structure for Date/Time */
+    RBUS_STRING,            /**< null terminated C style string */
+    RBUS_BYTES,             /**< byte array */
+    RBUS_PROPERTY,          /**< property instance */
+    RBUS_OBJECT,            /**< object instance */
+    RBUS_NONE
+} rbusValueType_t;
+
+typedef void* rbusHandle_t;
+typedef void* rbusValue_t;
+

--- a/unittest/mocks/mock_rdm_utils.h
+++ b/unittest/mocks/mock_rdm_utils.h
@@ -1,3 +1,21 @@
+/**
+ * Copyright 2023 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 #ifndef MOCK_RDM_UTILS_H
 #define MOCK_RDM_UTILS_H
 
@@ -7,6 +25,7 @@ extern "C" {
     #include "rdm_types.h"
     #include "rdm.h"
     #include "rdm_utils.h"
+    #include "system_utils.h"
 }
 
 class MockRdmUtils {
@@ -16,6 +35,32 @@ public:
     MOCK_METHOD1(emptyFolder, INT32(const CHAR*));
     MOCK_METHOD1(getFreeSpace, UINT32(const CHAR*));
     MOCK_METHOD1(createDir, INT32(const CHAR*));
+    MOCK_METHOD(void*, doCurlInit, (), ());
+    MOCK_METHOD(INT32, doHttpFileDownload, (void*, FileDwnl_t*, MtlsAuth_t*, unsigned int, char*, int*), ());
+    MOCK_METHOD(void, doStopDownload, (void *), ());
+    MOCK_METHOD(void, copyCommandOutput, (char*, char*, int), ());
+    MOCK_METHOD(const char*, getExtension, (char*), ());
+    MOCK_METHOD(int, tarExtract, (char*, char*), ());
+    MOCK_METHOD(int, fileCheck, (char*), ());
+    MOCK_METHOD(void, rdmInitSslLib, (), ());
+    MOCK_METHOD(INT32, rdmOpensslRsafileSignatureVerify, (const CHAR*, size_t, const CHAR*, const CHAR*, CHAR*, INT32*), ());
+    MOCK_METHOD(INT32, rdmDecryptKey, (CHAR*), ());
+    MOCK_METHOD(unsigned int, getFileLastModifyTime, (CHAR*), ());
+    MOCK_METHOD(time_t, getCurrentSysTimeSec, (), ());
+    MOCK_METHOD(int, copyFiles, (char*, char*), ());
+    MOCK_METHOD(int, folderCheck, (char*), ());
+    MOCK_METHOD(int, removeFile, (char*), ());
+    MOCK_METHOD(JSON*, ParseJsonStr, (char*), ());
+    MOCK_METHOD(size_t, GetJsonVal, (JSON*, char*, char*, size_t), ());
+    MOCK_METHOD(int, FreeJson, (JSON*), ());
+    MOCK_METHOD(int, isDataInList, (char**, char*, int), ());
+    MOCK_METHOD(int, strSplit, (char*, char*, char**, int), ());
+    MOCK_METHOD(int, findPFileAll, (char*, char*, char**, int*, int), ());
+    MOCK_METHOD(void, qsString, (char**, unsigned int), ());
+    MOCK_METHOD(int, strRmDuplicate, (char**, int), ());
+    MOCK_METHOD(INT32, rdmJSONGetLen, (CHAR*, INT32*), ());
+    MOCK_METHOD(INT32, rdmJSONGetAppNames, (INT32, CHAR*), ());
+    MOCK_METHOD(INT32, rdmJSONGetAppDetName, (CHAR*, RDMAPPDetails*), ());
 };
 
 #endif // MOCK_RDM_UTILS_H

--- a/unittest/mocks/secure_wrapper.h
+++ b/unittest/mocks/secure_wrapper.h
@@ -1,0 +1,111 @@
+/**
+ * Copyright 2023 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#ifndef __SECURE_H
+#  define __SECURE_H
+#  ifdef __cplusplus
+extern "C" {
+#  endif
+
+__attribute__((nonnull))
+__attribute__((format(printf,1,2)))
+int v_secure_system(const char *command, ...);
+
+__attribute__((nonnull))
+__attribute__((format(printf,2,3)))
+FILE *v_secure_popen(const char *direction, const char *command, ...);
+
+__attribute__((nonnull))
+int v_secure_pclose(FILE *);
+
+/* OBSOLETE CONSTANTS */
+#define _SPIPE "|"
+#define _SOR "||"
+#define _SAND "&&"
+#define _SBG "&"
+#define _STHEN ";"
+
+/* The following is just some gcc magic to make sure
+ * 1) the format string isn't a variable
+ * 2) the number of arguments matches the format
+ * 3) popen's direction arg is "r" or "w"
+ */
+
+#if (defined (__GNUC__) && ((__GNUC__ > 4) || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6))) || defined(__clang__)
+#define PRAGMA_PUSH                \
+    _Pragma ("GCC diagnostic push")                       \
+    _Pragma ("GCC diagnostic error \"-Wformat\"")       \
+    _Pragma ("GCC diagnostic error \"-Wformat-security\"")
+#define PRAGMA_POP             \
+    _Pragma ("GCC diagnostic pop")
+#else
+#define PRAGMA_PUSH
+#define PRAGMA_POP
+#endif
+
+#define v_secure_system(fmt, args...) \
+	({ \
+		int ret; \
+                PRAGMA_PUSH; \
+		if (!__builtin_constant_p(fmt)) { \
+		extern void format_error() __attribute__((error("command argument cannot be a variable\nreplace \"sprintf(buffer, command, args); v_secure_system(buffer);\" with \"v_secure_system(command, args);\""))); \
+			format_error(); \
+		} \
+		ret = v_secure_system(fmt, ##args); \
+                PRAGMA_POP; \
+		ret; \
+	})
+
+#define v_secure_popen(direction, fmt, args...) \
+	({ \
+		FILE *ret; \
+                PRAGMA_PUSH; \
+		if ( \
+			__builtin_constant_p(*direction) && \
+			((direction[0] != 'r' && direction[0] != 'w') || direction[1] != '\0') \
+		) { \
+			extern void popen_check() __attribute__((error("v_secure_popen(direction, command, ...) direction must be \"r\" or \"w\""))); \
+			popen_check(); \
+		} \
+		if (!__builtin_constant_p(fmt)) { \
+			extern void format_error() __attribute__((error("command argument cannot be a variable"))); \
+			format_error(); \
+		} \
+		ret = v_secure_popen(direction, fmt, ##args); \
+		PRAGMA_POP; \
+                ret; \
+	})
+
+extern int system(const char *command) __attribute__((warning("please replace system() with v_secure_system()")));
+
+__attribute__((deprecated))
+__attribute__((warning("contains_secure_separator is obsolete")))
+static inline int contains_secure_separator(__attribute__((unused)) char *str) {
+	return 0;
+}
+
+extern int secure_system_call_p(const char *cmd, char *argv[]);
+extern int secure_system_call_vp(const char *cmd, ...);
+
+#  ifdef __cplusplus
+}
+#  endif
+#endif

--- a/unittest/mocks/system_utils.h
+++ b/unittest/mocks/system_utils.h
@@ -21,10 +21,19 @@
 #define VIDEO_UTILS_SYSTEM_UTILS_H_
 
 #include "rdk_fwdl_utils.h"
+#include "rdm_types.h"
+#include "rdm.h"
+#include "rdm_jsonquery.h"
+#include <cjson/cJSON.h>
 #include <unistd.h>
 #include <sys/stat.h>
 #include <dirent.h>
 #include <time.h>
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
 
 #define MAX_OUT_BUFF_POPEN 4096
 #define RDK_API_SUCCESS 0
@@ -32,6 +41,39 @@
 #define RDK_FILEPATH_LEN    128
 #define RDK_APP_PATH_LEN   256
 #define RDK_MB_SIZE        (1024 * 1024)
+#define DIRECT_BLOCK_FILENAME "/tmp/.lastdirectfail_cdl"
+
+
+typedef struct credential {
+    char cert_name[64];
+    char cert_type[16];
+    char key_pas[32];
+}MtlsAuth_t;
+
+typedef struct CommonDownloadData {
+    void* pvOut;
+    size_t datasize;        // data size
+    size_t memsize;         // allocated memory size (if applicable)
+} DownloadData;
+
+typedef struct hashParam {
+    char *hashvalue;
+    char *hashtime;
+}hashParam_t;
+
+typedef struct filedwnl {
+        char *pPostFields;
+        char *pHeaderData;
+        DownloadData *pDlData;
+        DownloadData *pDlHeaderData;
+        int chunk_dwnl_retry_time;
+        char url[128];
+        char pathname[64];
+        bool sslverify;
+        hashParam_t *hashData;
+}FileDwnl_t;
+
+typedef cJSON   JSON;
 
 /** Description: File present check.
  *
@@ -64,17 +106,17 @@ int createFile(const char *file_name);
 int eraseTGZItemsMatching(const char *folder, const char* file_name);
 size_t GetHwMacAddress( char *iface, char *pMac, size_t szBufSize );
 /* Filesystem functions */
-unsigned int getFreeSpace(char *path);
-unsigned int checkFileSystem(char *path);
+UINT32 getFreeSpace(const char *path);
+INT32 checkFileSystem(const char *path);
 int  findSize(char *fileName);
 int  findFile(char *dir, char *search);
-int  findPFile(char *dir, char *search, char *out);
+INT32  findPFile(const char *dir, const char *search, char *out);
 int  findPFileAll(char *path, char *search, char **out, int *found_t, int max_list);
-int  emptyFolder(char *dir);
+INT32  emptyFolder(const char *dir);
 int  removeFile(char *filePath);
 int  copyFiles(char *src, char *dst);
 int  fileCheck(char *pFilepath);
-char*  getExtension(char *filename);
+const char* getExtension(char *filename);
 char*  getPartStr(char *fullpath, char *delim);
 char*  getPartChar(char *fullpath, char delim);
 int  folderCheck(char *path);
@@ -90,5 +132,13 @@ void  qsString(char *arr[], unsigned int length);
 int strRmDuplicate(char **in, int len);
 int isDataInList(char **pList,char *pData,int count);
 void getStringValueFromFile(char* path, char* strtokvalue, char* string, char* outValue);
+JSON *ParseJsonStr(char *pJsonStr);
+size_t GetJsonVal( JSON *pJson, char *pValToGet, char *pOutputVal, size_t maxlen );
+int FreeJson(JSON *pJson);
+
+#ifdef __cplusplus
+}
+#endif
+
 #endif /* VIDEO_UTILS_SYSTEM_UTILS_H_ */
 

--- a/unittest/rdm_curl_gtest.cpp
+++ b/unittest/rdm_curl_gtest.cpp
@@ -1,3 +1,21 @@
+/**
+ * Copyright 2023 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 #include <gtest/gtest.h>
 #include <gmock/gmock.h>
 #include <cstring>

--- a/unittest/rdm_json_gtest.cpp
+++ b/unittest/rdm_json_gtest.cpp
@@ -1,3 +1,21 @@
+/**
+ * Copyright 2023 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 #include <fstream>
 #include <gtest/gtest.h>
 #include <gmock/gmock.h>

--- a/unittest/rdm_main_gtest.cpp
+++ b/unittest/rdm_main_gtest.cpp
@@ -1,3 +1,21 @@
+/**
+ * Copyright 2023 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 #include <gtest/gtest.h>
 #include <gmock/gmock.h>
 #include "rdm_types.h"

--- a/unittest/rdm_openssl_gtest.cpp
+++ b/unittest/rdm_openssl_gtest.cpp
@@ -1,0 +1,308 @@
+/**
+ * Copyright 2023 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+using ::testing::Return;
+#include <cstring>
+#include <openssl/evp.h>
+
+// Include the header file for the functions being tested
+extern "C" {
+    #include "rdm_types.h"
+    #include "rdm_openssl.h"
+
+}
+
+
+
+#define GTEST_DEFAULT_RESULT_FILEPATH "/tmp/Gtest_Report/"
+#define GTEST_DEFAULT_RESULT_FILENAME "rdmopenssl_gtest_report.json"
+#define GTEST_REPORT_FILEPATH_SIZE 256
+
+
+
+// Mock class for static functions
+class MockRdmOpenssl {
+public:
+    MOCK_METHOD(int, asciihex_to_bin, (const char* asciihex, size_t asciihex_length, uint8_t* bin, size_t* bin_length));
+    MOCK_METHOD(int, bin_to_asciihex, (const uint8_t* bin, size_t bin_length, char* asciihex, size_t* asciihex_length));
+    MOCK_METHOD(int, rdm_openssl_file_hash_sha256, (const char* data_file, size_t file_len, uint8_t* hash_buffer, int32_t* buffer_len));
+    MOCK_METHOD(int, rdm_openssl_file_hash_sha256_pkg_components, (const char* data_file, size_t file_len, uint8_t* hash_buffer, int32_t* buffer_len));
+    MOCK_METHOD(int, prepare_sig_file, (CHAR* sig_file)); // Add this line for `prepare_sig_file`
+    MOCK_METHOD(int, prepare_app_manifest, (CHAR* etc_manifest_file, CHAR* cache_manifest_file, CHAR* padding_file, CHAR* prefix));
+};
+
+// Global mock object
+MockRdmOpenssl* global_mock = nullptr;
+
+// Mock function definitions
+extern "C" {
+    int v_secure_system(const char* format, ...) {
+        va_list args;
+        va_start(args, format);
+        vprintf(format, args); // Optionally log the command
+        va_end(args);
+
+        return 0; // Always return success
+    }
+    int asciihex_to_bin(const char* asciihex, size_t asciihex_length, uint8_t* bin, size_t* bin_length) {
+        return global_mock->asciihex_to_bin(asciihex, asciihex_length, bin, bin_length);
+    }
+
+    int bin_to_asciihex(const uint8_t* bin, size_t bin_length, char* asciihex, size_t* asciihex_length) {
+        return global_mock->bin_to_asciihex(bin, bin_length, asciihex, asciihex_length);
+    }
+
+
+
+    int rdm_openssl_file_hash_sha256(const char* data_file, size_t file_len, uint8_t* hash_buffer, int32_t* buffer_len) {
+        return global_mock->rdm_openssl_file_hash_sha256(data_file, file_len, hash_buffer, buffer_len);
+    }
+
+
+    int rdm_openssl_file_hash_sha256_pkg_components(const char* data_file, size_t file_len, uint8_t* hash_buffer, int32_t* buffer_len) {
+        return global_mock->rdm_openssl_file_hash_sha256_pkg_components(data_file, file_len, hash_buffer, buffer_len);
+    }
+
+   int prepare_sig_file(CHAR* sig_file) {
+        return global_mock->prepare_sig_file(sig_file); // Mock implementation for `prepare_sig_file`
+    }
+
+    int prepare_app_manifest(CHAR* etc_manifest_file, CHAR* cache_manifest_file, CHAR* padding_file, CHAR* prefix) {
+        return global_mock->prepare_app_manifest(etc_manifest_file, cache_manifest_file, padding_file, prefix);
+    }
+
+}
+
+TEST(OpenSSLTests, RdmOpensslFileHashSha256PkgComponents_ValidInput) {
+    MockRdmOpenssl mock;
+    global_mock = &mock;
+
+    const char* data_file = "valid_manifest.txt"; // Simulate a valid manifest file
+    size_t file_len = 1024; // Example file length
+    uint8_t hash_buffer[SHA256_DIGEST_LENGTH] = {0};
+    int32_t buffer_len = SHA256_DIGEST_LENGTH;
+
+    EXPECT_CALL(mock, rdm_openssl_file_hash_sha256_pkg_components(data_file, file_len, hash_buffer, &buffer_len))
+        .Times(1)
+        .WillOnce(testing::Return(0));
+
+    int result = rdm_openssl_file_hash_sha256_pkg_components(data_file, file_len, hash_buffer, &buffer_len);
+
+    EXPECT_EQ(result, 0);
+    EXPECT_EQ(buffer_len, SHA256_DIGEST_LENGTH); // Ensure buffer length is correct
+    global_mock = nullptr;
+}
+
+TEST(OpenSSLTests, RdmOpensslFileHashSha256PkgComponents_InvalidInput) {
+    MockRdmOpenssl mock;
+    global_mock = &mock;
+
+    const char* data_file = nullptr; // Simulate invalid input
+    size_t file_len = 0;
+    uint8_t hash_buffer[SHA256_DIGEST_LENGTH] = {0};
+    int32_t buffer_len = SHA256_DIGEST_LENGTH;
+
+    EXPECT_CALL(mock, rdm_openssl_file_hash_sha256_pkg_components(data_file, file_len, hash_buffer, &buffer_len))
+        .Times(1)
+        .WillOnce(testing::Return(retcode_param_error));
+
+    int result = rdm_openssl_file_hash_sha256_pkg_components(data_file, file_len, hash_buffer, &buffer_len);
+
+    EXPECT_EQ(result, retcode_param_error);
+    global_mock = nullptr;
+}
+
+// Example test for `prepare_sig_file`
+TEST(OpenSSLTests, PrepareSigFile_ValidInput) {
+    MockRdmOpenssl mock;
+    global_mock = &mock;
+
+    CHAR* sig_file = (CHAR*)"test_sig_file.txt";
+
+    EXPECT_CALL(mock, prepare_sig_file(sig_file))
+        .Times(1)
+        .WillOnce(testing::Return(0));
+
+    int result = prepare_sig_file(sig_file);
+
+    EXPECT_EQ(result, 0);
+    global_mock = nullptr;
+}
+
+TEST(OpenSSLTests, PrepareSigFile_InvalidInput) {
+    MockRdmOpenssl mock;
+    global_mock = &mock;
+
+    CHAR* sig_file = nullptr; // Invalid input
+
+    EXPECT_CALL(mock, prepare_sig_file(sig_file))
+        .Times(1)
+        .WillOnce(testing::Return(1));
+
+    int result = prepare_sig_file(sig_file);
+
+    EXPECT_EQ(result, 1);
+    global_mock = nullptr;
+}
+
+TEST(OpenSSLTests, AsciiHexToBin_ValidInput) {
+    MockRdmOpenssl mock;
+    global_mock = &mock;
+
+    const char* asciihex = "4A6F686E446F65";
+    size_t asciihex_length = strlen(asciihex);
+    uint8_t bin[8] = {0};
+    size_t bin_length = sizeof(bin);
+
+    EXPECT_CALL(mock, asciihex_to_bin(asciihex, asciihex_length, bin, &bin_length))
+        .Times(1)
+        .WillOnce(testing::Return(0));
+
+    int result = asciihex_to_bin(asciihex, asciihex_length, bin, &bin_length);
+
+    EXPECT_EQ(result, 0);
+    global_mock = nullptr;
+}
+
+
+TEST(OpenSSLTests, AsciiHexToBin_InvalidInput) {
+    MockRdmOpenssl mock;
+    global_mock = &mock;
+
+    const char* asciihex = "123"; // Odd-length string
+    size_t asciihex_length = strlen(asciihex);
+    uint8_t bin[8] = {0};
+    size_t bin_length = sizeof(bin);
+
+    EXPECT_CALL(mock, asciihex_to_bin(asciihex, asciihex_length, bin, &bin_length))
+        .Times(1)
+        .WillOnce(testing::Return(-1));
+
+    int result = asciihex_to_bin(asciihex, asciihex_length, bin, &bin_length);
+
+    EXPECT_EQ(result, -1);
+    global_mock = nullptr;
+}
+
+TEST(OpenSSLTests, BinToAsciiHex_ValidInput) {
+    MockRdmOpenssl mock;
+    global_mock = &mock;
+
+    const uint8_t bin[] = {0x4A, 0x6F, 0x68, 0x6E, 0x44, 0x6F, 0x65};
+    size_t bin_length = sizeof(bin);
+    char asciihex[16] = {0};
+    size_t asciihex_length = sizeof(asciihex);
+
+    EXPECT_CALL(mock, bin_to_asciihex(bin, bin_length, asciihex, &asciihex_length))
+        .Times(1)
+        .WillOnce(testing::Return(0));
+
+    int result = bin_to_asciihex(bin, bin_length, asciihex, &asciihex_length);
+
+    EXPECT_EQ(result, 0);
+    global_mock = nullptr;
+}
+
+TEST(OpenSSLTests, DumpBuffer_DebugEnabled) {
+    char buffer[] = "Test buffer";
+    int32_t buffer_size = strlen(buffer);
+    char name[] = "test_file";
+
+    // Call the actual `dump_buffer` implementation
+    dump_buffer(buffer, buffer_size, name);
+
+    // If `dump_buffer` logs or prints, capture and validate the output if necessary
+    SUCCEED(); // Test passes if no exceptions or errors
+}
+
+TEST(OpenSSLTests, RdmOpensslFileHashSha256_ValidInput) {
+    MockRdmOpenssl mock;
+    global_mock = &mock;
+
+    const char* data_file = "test_data_file";
+    uint8_t hash_buffer[SHA256_DIGEST_LENGTH] = {0};
+    int32_t buffer_len = sizeof(hash_buffer);
+
+    EXPECT_CALL(mock, rdm_openssl_file_hash_sha256(data_file, -1, hash_buffer, &buffer_len))
+        .Times(1)
+        .WillOnce(testing::Return(0));
+
+    int result = rdm_openssl_file_hash_sha256(data_file, -1, hash_buffer, &buffer_len);
+
+    EXPECT_EQ(result, 0);
+    global_mock = nullptr;
+}
+
+TEST(OpenSSLTests, RdmInitSslLib_MultipleCalls) {
+    // Test `rdmInitSslLib` directly as it is not static
+    rdmInitSslLib();
+    rdmInitSslLib();
+    SUCCEED(); // If no crashes, the test passes
+}
+TEST(OpenSSLTests, RdmOpensslRsafileSignatureVerify_InvalidInput) {
+    const char* data_file = nullptr; // Invalid input
+    size_t file_len = 0;
+    const char* sig_file = nullptr;
+    const char* vkey_file = nullptr;
+    char reply_msg[256] = {0};
+    int32_t reply_msg_len = sizeof(reply_msg);
+
+    int result = rdmOpensslRsafileSignatureVerify(data_file, file_len, sig_file, vkey_file, reply_msg, &reply_msg_len);
+
+    EXPECT_EQ(result, retcode_param_error);
+}
+
+TEST(OpenSSLTests, PrepareAppManifest_ValidInput) {
+    MockRdmOpenssl mock;
+    global_mock = &mock;
+
+    CHAR* etc_manifest_file = (CHAR*)"valid_manifest.txt";
+    CHAR* cache_manifest_file = (CHAR*)"cache_manifest.txt";
+    CHAR* padding_file = (CHAR*)"padding_file.txt";
+    CHAR* prefix = (CHAR*)"/prefix/";
+
+    EXPECT_CALL(mock, prepare_app_manifest(etc_manifest_file, cache_manifest_file, padding_file, prefix))
+        .Times(1)
+        .WillOnce(testing::Return(0));
+
+    int result = prepare_app_manifest(etc_manifest_file, cache_manifest_file, padding_file, prefix);
+
+    EXPECT_EQ(result, 0);
+    global_mock = nullptr;
+}
+
+TEST(OpenSSLTests, PrepareAppManifest_InvalidInput) {
+    MockRdmOpenssl mock;
+    global_mock = &mock;
+
+    CHAR* etc_manifest_file = nullptr;  // Invalid input
+    CHAR* cache_manifest_file = (CHAR*)"cache_manifest.txt";
+    CHAR* padding_file = (CHAR*)"padding_file.txt";
+    CHAR* prefix = (CHAR*)"/prefix/";
+
+    EXPECT_CALL(mock, prepare_app_manifest(etc_manifest_file, cache_manifest_file, padding_file, prefix))
+        .Times(1)
+        .WillOnce(testing::Return(1));
+
+    int result = prepare_app_manifest(etc_manifest_file, cache_manifest_file, padding_file, prefix);
+
+    EXPECT_EQ(result, 1);
+    global_mock = nullptr;
+}

--- a/unittest/rdm_rbus_gtest.cpp
+++ b/unittest/rdm_rbus_gtest.cpp
@@ -1,0 +1,112 @@
+/**
+ * Copyright 2023 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+
+extern "C" {
+    #include "mocks/mock_rdm_rbus.h"
+}
+
+#define GTEST_DEFAULT_RESULT_FILEPATH "/tmp/Gtest_Report/"
+#define GTEST_DEFAULT_RESULT_FILENAME "rdmdownload_gtest_report.json"
+#define GTEST_REPORT_FILEPATH_SIZE 256
+#define RBUS_ERROR_SUCCESS 0
+using ::testing::_;
+using ::testing::Return;
+
+MockRdmRbus* mockRdmRbus = new MockRdmRbus();
+
+extern "C"{
+    rbusValueType_t rbusValue_GetType(void* paramName) {
+        return mockRdmRbus->rbusValue_GetType(paramName);
+    }
+
+    INT32 rbus_get(void* handle, INT8* val, void** paramName) {
+        return mockRdmRbus->rbus_get(handle, val, paramName);
+    }
+
+    bool rbusValue_GetBoolean(void* paramName) {
+        return mockRdmRbus->rbusValue_GetBoolean(paramName);
+    }
+
+    INT8* rbusValue_ToString(void* str, void* paramName, int len) {
+	return mockRdmRbus->rbusValue_ToString(str, paramName, len);
+    }
+
+    void rbusValue_Release(void* ptr) {
+	return mockRdmRbus->rbusValue_Release(ptr);
+    }
+
+    INT32 rbus_checkStatus() {
+	return mockRdmRbus->rbus_checkStatus();
+    }
+
+    INT32 rbus_open(void* handle, INT8 *name) {
+	return mockRdmRbus->rbus_open(handle, name);
+    }
+
+    INT32 rbus_close(void* handle) {
+	return mockRdmRbus->rbus_close(handle);
+    }
+}
+
+// Test rdmRbusGetRfc
+TEST(rdmRbusGetRfc, rdmRbusGetRfc_SuccessBool) {
+
+    void* mockValue = static_cast<void*>(new int(0));
+    char rdmRFCName[128] = "Path.To.My.RFC";
+    INT8 *ipName = rdmRFCName;
+
+    EXPECT_CALL(*mockRdmRbus, rbusValue_GetType(::testing::_))
+        .WillOnce(Return(RBUS_BOOLEAN));
+
+    EXPECT_CALL(*mockRdmRbus, rbus_get(::testing::_, ::testing::_, ::testing::_))
+        .WillOnce(Return(RBUS_ERROR_SUCCESS));
+
+    //MOCK_METHOD(INT8*, rbusValue_ToString, (void*, void*, int), ());
+    EXPECT_CALL(*mockRdmRbus, rbusValue_GetBoolean(::testing::_))
+        .WillOnce(Return(true));
+
+    EXPECT_EQ(rdmRbusGetRfc(mockValue, ipName, mockValue), RDM_SUCCESS);
+
+    delete static_cast<int*>(mockValue);
+    delete mockRdmRbus;
+
+}
+
+TEST(rdmRbusGetRfc, rdmRbusGetRfc_Failure) {
+
+    void* mockValue = static_cast<void*>(new int(0));
+    char rdmRFCName[128] = "Path.To.My.RFC";
+    INT8 *ipName = rdmRFCName;
+
+    EXPECT_EQ(rdmRbusGetRfc(NULL, ipName, mockValue), RDM_FAILURE);
+    EXPECT_EQ(rdmRbusGetRfc(mockValue, NULL, mockValue), RDM_FAILURE);
+    EXPECT_EQ(rdmRbusGetRfc(mockValue, ipName, NULL), RDM_FAILURE);
+
+    delete static_cast<int*>(mockValue);
+
+}
+
+
+int main(int argc, char** argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}
+

--- a/unittest/rdm_utils_gtest.cpp
+++ b/unittest/rdm_utils_gtest.cpp
@@ -1,3 +1,21 @@
+/**
+ * Copyright 2023 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 #include <gtest/gtest.h>
 #include <gmock/gmock.h>
 #include "unittest/mocks/mock_iarm_bus.h"


### PR DESCRIPTION
Reason for change: Add L1 test coverage for coverity fixes
Test Procedure: Build RDKE image
Risks: Low

Signed-off-by: Aravindan NC [nc.aravindan@gmail.com](mailto:nc.aravindan@gmail.com)