### PR TITLE
RDKEMW-3588: Fix rdmDwnlRunPostScripts()

### DIFF
--- a/include/rdm_downloadutils.h
+++ b/include/rdm_downloadutils.h
@@ -68,7 +68,7 @@ INT32  rdmDwnlGetCert(MtlsAuth_t*);
 INT32  rdmDwnlUpdateManifest(CHAR *pInManifest, CHAR *pOutManifest, CHAR *update, CHAR *padding);
 #endif
 VOID   rdmRemvDwnlAppInfo(CHAR *pAppName, CHAR *pDwnlInfoFile);
-INT32  rdmDwnlRunPostScripts(CHAR *pAppHome);
+INT32  rdmDwnlRunPostScripts(CHAR *pAppHome, INT32 versioned_app);
 UINT32 rdmDwnlIsBlocked(CHAR *file, INT32 block_time);
 VOID   rdmDwnlUnInstallApp(CHAR *pDwnlPath, CHAR *pAppPath);
 INT32  rdmJRPCTokenData(CHAR *token,CHAR *pJsonStr,UINT32 token_size);

--- a/rdm_main.c
+++ b/rdm_main.c
@@ -329,11 +329,16 @@ error1:
 
     if(download_status == 0) {
         RDMInfo("App download success, sending status as %d\n", download_status);
-        rdmUnInstallApps(is_broadband);
-        ret = rdmIARMEvntSendStatus(RDM_PKG_UNINSTALL);
-        if(ret) {
-            RDMError("Failed to send the IARM event\n");
-        }
+	if(pApp_det->is_versioned_app) {
+            RDMINFO("Post Installation Successful for %s\n", pApp_det->app_name);
+	    return download_status;
+	} else {
+            rdmUnInstallApps(is_broadband);
+            ret = rdmIARMEvntSendStatus(RDM_PKG_UNINSTALL);
+            if(ret) {
+               RDMError("Failed to send the IARM event\n");
+            }
+	}
     }
     else {
         RDMInfo("App download failed, sending status as %d\n", download_status);

--- a/rdm_main.c
+++ b/rdm_main.c
@@ -305,11 +305,13 @@ int main(int argc, char* argv[])
 	    RDMInfo("Install App from custom path: %s\n", app_name);
 	    char *ver = strchr(app_name, ':');
 	    if (ver != NULL) {
-		    strcpy(pApp_det->pkg_ver, ver + 1);
+		    strncpy(pApp_det->pkg_ver, ver + 1, sizeof(pApp_det->pkg_ver) - 1);
+		    pApp_det->pkg_ver[sizeof(pApp_det->pkg_ver) - 1] = '\0';
 	    }
 	    sscanf(app_name, "%[^:]", result);
-	    strcpy(pApp_det->app_name, result);
-	    sprintf(pApp_det->pkg_name, "%s_%s-signed.tar", result, pApp_det->pkg_ver);
+	    strncpy(pApp_det->app_name, result, sizeof(pApp_det->app_name) - 1);
+            pApp_det->app_name[sizeof(pApp_det->app_name) - 1] = '\0';
+	    snprintf(pApp_det->pkg_name, sizeof(pApp_det->pkg_name), "%s_%s-signed.tar", result, pApp_det->pkg_ver);
 	    RDMInfo("pkg_name_signed = %s\n", pApp_det->pkg_name);
 	    pApp_det->is_versioned_app = 1;
 

--- a/rdm_main.c
+++ b/rdm_main.c
@@ -330,7 +330,7 @@ error1:
     if(download_status == 0) {
         RDMInfo("App download success, sending status as %d\n", download_status);
 	if(pApp_det->is_versioned_app) {
-            RDMINFO("Post Installation Successful for %s\n", pApp_det->app_name);
+            RDMInfo("Post Installation Successful for %s\n", pApp_det->app_name);
 	    return download_status;
 	} else {
             rdmUnInstallApps(is_broadband);

--- a/src/rdm_download.c
+++ b/src/rdm_download.c
@@ -127,7 +127,7 @@ INT32 rdmDownloadApp(RDMAPPDetails *pRdmAppDet, INT32 *pDLStatus)
 
     /*Clearing pkg type for the usb thunder plugin download*/
     if(pRdmAppDet->is_usb == 1){
-        strcpy(pRdmAppDet->pkg_type, "\0");
+        strncpy(pRdmAppDet->pkg_type, "\0", sizeof(pRdmAppDet->pkg_type));
     }
 
     /* Versioned app installation */

--- a/src/rdm_downloadmgr.c
+++ b/src/rdm_downloadmgr.c
@@ -337,7 +337,7 @@ INT32 rdmDownloadMgr(RDMAPPDetails *pRdmAppDet)
                            pRdmAppDet->app_home,
                            RDM_PKG_INSTALL_COMPLETE);
     }
-    rdmDwnlRunPostScripts(pRdmAppDet->app_home);
+    rdmDwnlRunPostScripts(pRdmAppDet->app_home, pRdmAppDet->is_versioned_app);
 
 error:
     return rdm_status;

--- a/src/rdm_downloadutils.c
+++ b/src/rdm_downloadutils.c
@@ -412,7 +412,7 @@ VOID rdmMemDLFree(VOID *pvDwnData)
     memset(pvDwnData, 0, sizeof(DownloadData));
 }
 
-INT32 rdmDwnlRunPostScripts(CHAR *pAppHome)
+INT32 rdmDwnlRunPostScripts(CHAR *pAppHome, INT32 versioned_app)
 {
     CHAR tmp_file[RDM_APP_PATH_LEN];
     CHAR filePath[RDM_APP_PATH_LEN];

--- a/src/rdm_jsonquery.c
+++ b/src/rdm_jsonquery.c
@@ -333,7 +333,8 @@ INT32 rdmJSONGetAppDetID(INT32          idx,
     ret = rdmJSONQuery(RDM_MANIFEST, json_path, pRdmAppDet->dwld_method_controller);
     if(ret) {
         RDMWarn("Unable to get dwld_method_controller\n");
-        strncpy(pRdmAppDet->dwld_method_controller, "None", sizeof(pRdmAppDet->dwld_method_controller));
+	strncpy(pRdmAppDet->dwld_method_controller, "None", sizeof(pRdmAppDet->dwld_method_controller) - 1);
+        pRdmAppDet->dwld_method_controller[sizeof(pRdmAppDet->dwld_method_controller) - 1] = '\0'; //Null terminate the string
     }
 
     snprintf(json_path, RDM_JSONPATH_LEN, "%s/%d/%s", RDM_MANIFEST_PATH, idx, RDM_JSONQ_PKGNAME);

--- a/unittest/rdm_downloadutils_gtest.cpp
+++ b/unittest/rdm_downloadutils_gtest.cpp
@@ -232,6 +232,7 @@ TEST(rdmDwnlGetCert, rdmDwnlGetCert_Success) {
 // Test rdmDwnlRunPostScripts
 TEST(rdmDwnlRunPostScripts, rdmDwnlRunPostScripts_Success) {
     char pAppHome[32] = "/media/apps";
+    INT32 versionedapp = 0;    
     //static char ext[3] = "sh";
     system("mkdir -p /media/apps/etc/rdm/post-services/");
     system("touch /media/apps/etc/rdm/post-services/post-install.sh");
@@ -244,13 +245,14 @@ TEST(rdmDwnlRunPostScripts, rdmDwnlRunPostScripts_Success) {
     EXPECT_CALL(*mockRdmUtils, getExtension(::testing::_))
         .WillOnce(Return("sh"));
     EXPECT_CALL(*mockRdmUtils, copyCommandOutput(::testing::_, ::testing::_, ::testing::_));
-    EXPECT_EQ(rdmDwnlRunPostScripts(pAppHome), RDM_SUCCESS);
+    EXPECT_EQ(rdmDwnlRunPostScripts(pAppHome, versionedapp), RDM_SUCCESS);
 
 }
 
 TEST(rdmDwnlRunPostScripts, rdmDwnlRunPostScripts_Failure) {
     char pAppHome[32] = "/tmp/some_path";
-    EXPECT_EQ(rdmDwnlRunPostScripts(pAppHome), RDM_FAILURE);
+    INT32 versionedapp = 0;
+    EXPECT_EQ(rdmDwnlRunPostScripts(pAppHome, versionedapp), RDM_FAILURE);
 }
 
 // Test rdmUnInstallApps


### PR DESCRIPTION
RDKEMW-3588 : Fix rdmDwnlRunPostScripts()

Reason for change :
When a profile is downloaded via rdmagent, After Download and Signature Validation is completed, There executes the script which uninstall the unwanted packages available in the manifest.

But in the case of VersionedApp, no packages needs to be uninstalled from the Manifest.
In Current Scenario, Uninstalling manifests packages is handled for Versioned apps as well.