### PR TITLE
DELIA-68200: [RDKE] RDM manifest is empty, rdm downloaded packages still exist in device

### DIFF
--- a/rdm_main.c
+++ b/rdm_main.c
@@ -330,7 +330,7 @@ int main(int argc, char* argv[])
     }
 
 error1:
-    rdmDwnlCleanUp(pApp_det);
+    rdmDwnlUnInstallApp(pApp_det->app_dwnl_path, pApp_det->app_home);
 
     if(download_status == 0) {
         RDMInfo("App download success, sending status as %d\n", download_status);

--- a/rdm_main.c
+++ b/rdm_main.c
@@ -330,7 +330,7 @@ int main(int argc, char* argv[])
     }
 
 error1:
-    //rdmDwnlCleanUp(pApp_det);
+    rdmDwnlCleanUp(pApp_det);
 
     if(download_status == 0) {
         RDMInfo("App download success, sending status as %d\n", download_status);

--- a/rdm_main.c
+++ b/rdm_main.c
@@ -330,7 +330,6 @@ int main(int argc, char* argv[])
     }
 
 error1:
-    rdmDwnlUnInstallApp(pApp_det->app_dwnl_path, pApp_det->app_home);
 
     if(download_status == 0) {
         RDMInfo("App download success, sending status as %d\n", download_status);
@@ -347,6 +346,7 @@ error1:
     }
     else {
         RDMInfo("App download failed, sending status as %d\n", download_status);
+	rdmUnInstallApps(is_broadband);
     }
 
     ret = rdmIARMEvntSendStatus(download_status);

--- a/rdm_main.c
+++ b/rdm_main.c
@@ -347,6 +347,10 @@ error1:
     else {
         RDMInfo("App download failed, sending status as %d\n", download_status);
 	rdmUnInstallApps(is_broadband);
+	ret = rdmIARMEvntSendStatus(RDM_PKG_UNINSTALL);
+            if(ret) {
+               RDMError("Failed to send the IARM event\n");
+            }
     }
 
     ret = rdmIARMEvntSendStatus(download_status);


### PR DESCRIPTION
Reason for change: Add fix to remove packages on exit
Test Procedure: Build RDKE image
Risks: Low

Signed-off-by: Aravindan NC [nc.aravindan@gmail.com](mailto:nc.aravindan@gmail.com)