### PR TITLE
RDKEMW-3685: [RDKE]-Review and Cleanup Disabled Services

### DIFF
--- a/apps-rdm.service
+++ b/apps-rdm.service
@@ -18,7 +18,6 @@
 ##############################################################################
 [Unit]
 Description= Apps Download Service
-After=swupdate.service
 ConditionPathExists=/tmp/.xconfssrdownloadurl
 
 [Service]


### PR DESCRIPTION
Issue Description : [RDKE] - Review and Cleanup Unused Services.
Fix Provided : Services swupdate.service, rfc-config.service and dcm-log.service are nowhere used and not available in system. Hence, code changes done to remove these services in RDKE.
Test Done : 
  1> Verify whether the removed services are present in rootfs.
  2> Verified whether all logs are generated under /opt/logs folder.
  3> Basic sanity