### PR TITLE
DELIA-69609 : Memcapture package is downloaded by RDM when RFC is not enabled

### DIFF
--- a/src/rdm_downloadutils.c
+++ b/src/rdm_downloadutils.c
@@ -896,6 +896,8 @@ INT32 rdmUpdateAppDetails(RDMHandle *prdmHandle,
     if (ret != RDM_SUCCESS) {
         RDMWarn("Failed to Get RDM url from rbus\n");
         memset(pRdmAppDet->app_dwnl_url, 0, sizeof(pRdmAppDet->app_dwnl_url));
+	RDMError("RFC is not Enabled for RDM_RFC_URL\n");
+	return RDM_FAILURE;
     }
 
 
@@ -906,6 +908,8 @@ INT32 rdmUpdateAppDetails(RDMHandle *prdmHandle,
     if (ret != RDM_SUCCESS) {
         RDMWarn("Failed to Get mtls status from rbus\n");
         pRdmAppDet->is_mtls = 1;
+	RDMError("RFC is not Enabled for RDM_RFC_MTLS\n");
+	return RDM_FAILURE;
     }
 
 #ifdef RDM_ENABLE_CODEBIG

--- a/src/rdm_downloadutils.c
+++ b/src/rdm_downloadutils.c
@@ -896,8 +896,10 @@ INT32 rdmUpdateAppDetails(RDMHandle *prdmHandle,
     if (ret != RDM_SUCCESS) {
         RDMWarn("Failed to Get RDM url from rbus\n");
         memset(pRdmAppDet->app_dwnl_url, 0, sizeof(pRdmAppDet->app_dwnl_url));
-	RDMError("RFC is not Enabled for RDM_RFC_URL\n");
-	return RDM_FAILURE;
+		if (!(pRdmAppDet->app_dwnl_url)) {
+	        RDMError("RFC is not Enabled for RDM_RFC_URL %s\n", RDM_RFC_URL);
+		}
+	    return RDM_FAILURE;
     }
 
 
@@ -908,8 +910,8 @@ INT32 rdmUpdateAppDetails(RDMHandle *prdmHandle,
     if (ret != RDM_SUCCESS) {
         RDMWarn("Failed to Get mtls status from rbus\n");
         pRdmAppDet->is_mtls = 1;
-	RDMError("RFC is not Enabled for RDM_RFC_MTLS\n");
-	return RDM_FAILURE;
+        RDMError("RFC is not Enabled for RDM_RFC_MTLS\n");
+        return RDM_FAILURE;
     }
 
 #ifdef RDM_ENABLE_CODEBIG

--- a/src/rdm_downloadutils.c
+++ b/src/rdm_downloadutils.c
@@ -896,7 +896,7 @@ INT32 rdmUpdateAppDetails(RDMHandle *prdmHandle,
     if (ret != RDM_SUCCESS) {
         RDMWarn("Failed to Get RDM url from rbus\n");
         memset(pRdmAppDet->app_dwnl_url, 0, sizeof(pRdmAppDet->app_dwnl_url));
-		if (!(pRdmAppDet->app_dwnl_url)) {
+		if (!pRdmAppDet || pRdmAppDet->app_dwnl_url[0] == '\0') {
 	        RDMError("RFC is not Enabled for RDM_RFC_URL %s\n", RDM_RFC_URL);
 		}
 	    return RDM_FAILURE;


### PR DESCRIPTION
Reason for Change : Added a statement to skip a download when RFC is not enabled.
Test Procedure : Build and Test rdm package download