### PR TITLE
RDK-60393: RDM - Old packages are not uninstalled from the device (#94)

### DIFF
--- a/include/rdm_downloadutils.h
+++ b/include/rdm_downloadutils.h
@@ -90,7 +90,7 @@ INT32  rdmMemDLAlloc(VOID *pDwnData, size_t szDataSize);
 VOID   rdmMemDLFree(VOID *pvDwnData);
 INT32  rdmDwnlValidation(RDMAPPDetails *pRdmAppDet, CHAR *pVer);
 INT32  rdmDwnlDirect(CHAR* pUrl, CHAR* pDwnlPath, CHAR* pPkgName, CHAR* pOut);
-INT32 rdmUnInstallApps(INT32 is_broadband );
+INT32 rdmUnInstallApps(RDMHandle *prdmHandle, INT32 is_broadband );
 INT32 rdmGetManifestApps(CHAR **pAppsInManifest, INT32 *numOfApps);
 INT32 rdmUpdateAppDetails(RDMHandle *prdmHandle,
                           RDMAPPDetails *pRdmAppDet,

--- a/rdm_main.c
+++ b/rdm_main.c
@@ -380,7 +380,7 @@ error1:
             RDMInfo("Post Installation Successful for %s\n", pApp_det->app_name);
 	    return download_status;
 	} else {
-            rdmUnInstallApps(is_broadband);
+            rdmUnInstallApps(prdmHandle, is_broadband);
             ret = rdmIARMEvntSendStatus(RDM_PKG_UNINSTALL);
             if(ret) {
                RDMError("Failed to send the IARM event\n");
@@ -389,7 +389,7 @@ error1:
     }
     else {
         RDMInfo("App download failed, sending status as %d\n", download_status);
-	rdmUnInstallApps(is_broadband);
+	rdmUnInstallApps(prdmHandle, is_broadband);
 	ret = rdmIARMEvntSendStatus(RDM_PKG_UNINSTALL);
         if(ret) {
             RDMError("Failed to send the IARM event\n");

--- a/src/rdm_downloadutils.c
+++ b/src/rdm_downloadutils.c
@@ -716,7 +716,7 @@ error:
  *  @return  Returns status of the function.
  *  @retval  Returns RDM_SUCCESS on success, RDM_FAILURE otherwise.
  **/
-INT32 rdmUnInstallApps(INT32  is_broadband)
+INT32 rdmUnInstallApps(RDMHandle *prdmHandle, INT32  is_broadband)
 {
     INT32 status                         = RDM_SUCCESS;
     CHAR *app_manifests[RDM_TMP_LEN_64]  = {0};
@@ -729,6 +729,8 @@ INT32 rdmUnInstallApps(INT32  is_broadband)
     RDMAPPDetails *pApp_det              = NULL;
     INT32 ret                            = RDM_SUCCESS;
     CHAR  pkg_file[RDM_APP_PATH_LEN]     = {0};
+	CHAR   rfc_app[256]                  = {0};
+    INT32 app_rfc_status                 = 0;
 
     RDMInfo("Uninstall the old packages that are not listed in current manifest\n");
 
@@ -790,17 +792,38 @@ INT32 rdmUnInstallApps(INT32  is_broadband)
                             if(pApp_det->dwld_on_demand) {
                                 RDMInfo("dwld_on_demand set to yes!!! Check RFC value of the APP to be downloaded\n");
                                 if(strcmp(pApp_det->dwld_method_controller, "RFC") != 0) {
-				    isAppUninstalled = 1;
+				                    isAppUninstalled = 1;
                                     RDMInfo("Packages to be uninstalled %s \n",app_installed[index]);
                                     rdmDwnlAppCleanUp(path);
                                     rdmRemvDwnlAppInfo(app_installed[index], pApp_det->app_dwnl_info);
                                     continue;
                                 }
+                                else {
+                                    RDMInfo("App is supported using RFC method for download, checking RFC status\n");
+                                    snprintf(rfc_app, sizeof(rfc_app),
+                                                  "Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.%s.Enable",
+                                                   pApp_det->app_name);
+
+                                    ret = rdmRbusGetRfc(prdmHandle->pRbusHandle,
+                                                   rfc_app,
+                                                   &app_rfc_status);
+
+
+                                    if (ret == RDM_SUCCESS && app_rfc_status == 0)
+                                    {
+                                        RDMInfo("APP RFC disabled, Deleting App  name=%s\n", pApp_det->app_name);
+                                        isAppUninstalled = 1;
+                                        RDMInfo("Packages to be uninstalled %s \n",app_installed[index]);
+                                        rdmDwnlAppCleanUp(path);
+                                        rdmRemvDwnlAppInfo(app_installed[index], pApp_det->app_dwnl_info);
+                                        continue;
+                                   }
+                               }									
                             }
                             RDMInfo(" Installed App %s is found in Manifest, so Skipping to next... \n", app_installed[index]);
                         }
                         else{
-			    isAppUninstalled = 1;
+			                isAppUninstalled = 1;
                             RDMInfo("Packages to be uninstalled %s \n",app_installed[index]);
                             rdmDwnlAppCleanUp(path);
                             rdmRemvDwnlAppInfo(app_installed[index], pApp_det->app_dwnl_info);
@@ -830,12 +853,32 @@ INT32 rdmUnInstallApps(INT32  is_broadband)
                                 if(pApp_det->dwld_on_demand) {
                                     RDMInfo("dwld_on_demand set to yes!!! Check RFC value of the APP to be downloaded\n");
                                     if(strcmp(pApp_det->dwld_method_controller, "RFC") != 0) {
-					isAppUninstalled = 1;
+					                    isAppUninstalled = 1;
                                         RDMInfo("Packages to be uninstalled %s \n",app_installed[index]);
                                         rdmDwnlAppCleanUp(path);
                                         rdmRemvDwnlAppInfo(app_installed[index], pApp_det->app_dwnl_info);
                                         continue;
                                     }
+                                    else {
+                                        RDMInfo("App is supported using RFC method for download, checking RFC status\n");
+                                        snprintf(rfc_app, sizeof(rfc_app),
+                                                  "Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.%s.Enable",
+                                                   pApp_det->app_name);
+
+                                        ret = rdmRbusGetRfc(prdmHandle->pRbusHandle,
+                                                   rfc_app,
+                                                   &app_rfc_status);
+
+                                        if (ret == RDM_SUCCESS && app_rfc_status == 0)
+                                        {
+                                            RDMInfo("APP RFC disabled, Deleting App  name=%s\n", pApp_det->app_name);
+                                            isAppUninstalled = 1;
+                                            RDMInfo("Packages to be uninstalled %s \n",app_installed[index]);
+                                            rdmDwnlAppCleanUp(path);
+                                            rdmRemvDwnlAppInfo(app_installed[index], pApp_det->app_dwnl_info);
+                                            continue;
+                                       }
+                                   }										
                                 }
                                 RDMInfo(" Installed App %s is found in Manifest, so Skipping to next... \n", app_installed[index]);
                             }

--- a/unittest/rdm_downloadutils_gtest.cpp
+++ b/unittest/rdm_downloadutils_gtest.cpp
@@ -284,7 +284,28 @@ TEST(rdmUnInstallApps, rdmUnInstallApps_Success) {
 	.WillRepeatedly(Return(RDM_SUCCESS));
     EXPECT_CALL(*mockRdmUtils, rdmJSONGetAppDetName(::testing::_, ::testing::_))
 	.WillRepeatedly(Return(RDM_SUCCESS));
-    EXPECT_EQ(rdmUnInstallApps(isBroadband), RDM_SUCCESS);
+
+    RDMHandle prdmHandle = {};
+    prdmHandle.pRbusHandle = static_cast<void*>(new int(0));
+
+    RDMAPPDetails appDetails = {};
+    strncpy(appDetails.app_name, "test_app", sizeof(appDetails.app_name) - 1);
+    strncpy(appDetails.pkg_name, "test_pkg", sizeof(appDetails.pkg_name) - 1);
+    strncpy(appDetails.app_mnt, "/mnt/test", sizeof(appDetails.app_mnt) - 1);
+    strncpy(appDetails.app_home, "/media/apps", sizeof(appDetails.app_home) - 1);
+    strncpy(appDetails.app_dwnl_path, "/downloads/test", sizeof(appDetails.app_dwnl_path) - 1);
+    strncpy(appDetails.app_dwnl_info, "/downloads/test/rdmDownloadInfo.txt", sizeof(appDetails.app_dwnl_info) - 1);
+    appDetails.app_size_mb = 100;
+    appDetails.bFsCheck = true;
+    appDetails.is_versioned = false;
+    appDetails.is_usb = 0;
+    appDetails.app_size_kb = 100;
+    
+    prdmHandle.pApp_det = &appDetails;
+
+    EXPECT_EQ(rdmUnInstallApps(&prdmHandle, isBroadband), RDM_SUCCESS);	
+    delete static_cast<int*>(prdmHandle.pRbusHandle);
+
 }
 
 // Test rdmDwnlValidation


### PR DESCRIPTION
* Update rdm_downloadutils.h

* Update rdm_main.c

* Update rdm_downloadutils.c

* Update rdm_downloadutils_gtest.cpp

* Update rdm_downloadutils_gtest.cpp

* Update rdm_downloadutils_gtest.cpp