### PR TITLE
RDK-61052 : STRING_OVERFLOW ERROR

### DIFF
--- a/src/rdm_download.c
+++ b/src/rdm_download.c
@@ -105,7 +105,6 @@ INT32 rdmDownloadApp(RDMAPPDetails *pRdmAppDet, INT32 *pDLStatus)
     CHAR *DLInfoPath = NULL;
     CHAR *DLInfoFile = NULL;
     INT32 DLInfoStatus = RDM_SUCCESS;
-    FILE  *fp_met = NULL;
 
     *pDLStatus = RDM_DL_NOERROR;
 

--- a/src/rdm_downloadutils.c
+++ b/src/rdm_downloadutils.c
@@ -140,7 +140,7 @@ INT32 rdmDwnlCreateFolder(CHAR *pAppPath, CHAR *pAppname)
     }
 
     strcat(tmp, "/");
-    strcat(tmp, pAppname);
+    strncat(tmp, pAppname, RDM_APP_PATH_LEN - strlen(tmp) - 1);
     status = createDir(tmp);
     if(status) {
         return RDM_FAILURE;
@@ -148,7 +148,7 @@ INT32 rdmDwnlCreateFolder(CHAR *pAppPath, CHAR *pAppname)
 
     strncpy(tmp, pAppPath, RDM_APP_PATH_LEN);
     strcat(tmp, "/");
-    strcat(tmp, pAppname);
+    strncat(tmp, pAppname,RDM_APP_PATH_LEN - strlen(tmp) - 1);
     status = createDir(tmp);
     if(status) {
         return RDM_FAILURE;
@@ -260,10 +260,7 @@ INT32 rdmDwnlDirect(CHAR *pUrl, CHAR *pDwnlPath, CHAR *pPkgName, CHAR *pOut)
     file_dwnl.chunk_dwnl_retry_time = 0;
     strncpy(file_dwnl.url, pUrl, sizeof(file_dwnl.url) - 1);
     file_dwnl.url[sizeof(file_dwnl.url) - 1] = '\0';  // Ensure null termination
-    strncpy(file_dwnl.pathname, pDwnlPath, sizeof(file_dwnl.pathname) -1);
-    strcat(file_dwnl.pathname, "/");
-    strcat(file_dwnl.pathname, pPkgName);
-    file_dwnl.pathname[sizeof(file_dwnl.pathname) - 1] = '\0';  // Ensure null termination
+    snprintf(file_dwnl.pathname, sizeof(file_dwnl.pathname), "%s/%s", pDwnlPath, pPkgName);
     strcpy(pOut, file_dwnl.pathname);
 
     if(rdmDwnlIsOCSPEnable()) {
@@ -567,19 +564,76 @@ INT32 rdmDwnlValidation(RDMAPPDetails *pRdmAppDet, CHAR *pVer)
         return RDM_FAILURE;
     }
 
-    strncpy(dwnl_path, pRdmAppDet->app_dwnl_path, RDM_APP_PATH_LEN);
-    dwnl_path[RDM_APP_PATH_LEN - 1] = '\0';  // Ensure null termination
-    if(pVer) {
-        strcat(dwnl_path, "/v");
-        strcat(dwnl_path, pVer);
-    }
-    strncpy(app_home, pRdmAppDet->app_home, RDM_APP_PATH_LEN);
-    if(pVer) {
-        strcat(app_home, "/v");
-        strcat(app_home, pVer);
-        strcat(app_home, "/package");
-    }
+    // Build dwnl_path safely
+    strncpy(dwnl_path, pRdmAppDet->app_dwnl_path, RDM_APP_PATH_LEN - 1);
+    dwnl_path[RDM_APP_PATH_LEN - 1] = '\0';
 
+    if(pVer) {
+        size_t curr_len = strlen(dwnl_path);
+        size_t remain = RDM_APP_PATH_LEN - curr_len - 1; // Reserve space for null terminator
+
+       // Append "/v"
+        if(remain >= 2) {  // "/v" == 2 chars
+            strncat(dwnl_path, "/v", remain);
+            curr_len = strlen(dwnl_path);
+            remain = RDM_APP_PATH_LEN - curr_len - 1;
+        } else {
+            RDMError("Not enough space to append /v to dwnl_path");
+	    free(out_buf);
+            return RDM_FAILURE;
+        }
+
+    // Append pVer
+        size_t ver_len = strlen(pVer);
+        if(remain >= ver_len) {
+            strncat(dwnl_path, pVer, remain);
+        } else {
+            RDMError("Not enough space to append version to dwnl_path");
+	    free(out_buf);
+            return RDM_FAILURE;
+        }
+   }
+
+// Build app_home safely
+   strncpy(app_home, pRdmAppDet->app_home, RDM_APP_PATH_LEN - 1);
+   app_home[RDM_APP_PATH_LEN - 1] = '\0';
+
+   if(pVer) {
+       size_t curr_len = strlen(app_home);
+       size_t remain = RDM_APP_PATH_LEN - curr_len - 1;
+
+    // Append "/v"
+       if(remain >= 2) {
+           strncat(app_home, "/v", remain);
+           curr_len = strlen(app_home);
+           remain = RDM_APP_PATH_LEN - curr_len - 1;
+       } else {
+           RDMError("Not enough space to append /v to app_home");
+	   free(out_buf);
+           return RDM_FAILURE;
+       }
+
+    // Append version
+       size_t ver_len = strlen(pVer);
+       if(remain >= ver_len) {
+           strncat(app_home, pVer, remain);
+           curr_len = strlen(app_home);
+           remain = RDM_APP_PATH_LEN - curr_len - 1;
+       } else {
+           RDMError("Not enough space to append version to app_home");
+	   free(out_buf);
+           return RDM_FAILURE;
+       }
+
+    // Append "/package"
+       if(remain >= 8) { // "/package" is 8 chars
+           strncat(app_home, "/package", remain);
+       } else {
+           RDMError("Not enough space to append /package to app_home");
+	   free(out_buf);
+           return RDM_FAILURE;
+       }
+    }
     if(findPFile(dwnl_path, "*-pkg.sig", pkg_file)) {
         /* Read the signature file */
         status = rdmDwnlReadSigFile(pkg_file, out_buf);

--- a/src/rdm_downloadverapp.c
+++ b/src/rdm_downloadverapp.c
@@ -309,12 +309,24 @@ static INT32 rdmDwnlVAInstall(RDMAPPDetails *pRdmAppDet, CHAR **ppVer, INT32 num
         RDMInfo("Install the %s version of %s\n", pRdmAppDet->app_name, ppVer[i]);
         pRdmAppDet->app_dwnl_path[dlen] = 0;
         pRdmAppDet->app_home[hlen] = 0;
-        strcat(pRdmAppDet->app_dwnl_path, "/v");
-        strcat(pRdmAppDet->app_dwnl_path, ppVer[i]);
-        strcat(pRdmAppDet->app_home, "/v");
-        strcat(pRdmAppDet->app_home, ppVer[i]);
-        strcat(pRdmAppDet->app_home, "/package");
-
+	size_t app_dwnl_total_len = dlen + 2 + strlen(ppVer[i]); 
+        if (app_dwnl_total_len < RDM_APP_PATH_LEN) {
+            strcat(pRdmAppDet->app_dwnl_path, "/v");
+            strcat(pRdmAppDet->app_dwnl_path, ppVer[i]);
+        } else {
+            RDMError("Version path exceeds buffer, skipping.\n");
+            continue;
+        } 
+	size_t needed_hlen = hlen + 2 + strlen(ppVer[i]) + 8; 
+        if (needed_hlen < RDM_APP_PATH_LEN) {
+            strcat(pRdmAppDet->app_home, "/v");
+            strcat(pRdmAppDet->app_home, ppVer[i]);
+            strcat(pRdmAppDet->app_home, "/package");
+        } else {
+            RDMError("App home path exceeds buffer length for %s/v%s/package\n", pRdmAppDet->app_name, ppVer[i]);
+            pRdmAppDet->app_dwnl_path[dlen] = 0;
+            continue;
+        }
         if(rdmDownloadMgr(pRdmAppDet)) {
             RDMError("Failed to Install the App %s version of %s\n", pRdmAppDet->app_name, ppVer[i]);
         }

--- a/src/rdm_downloadverapp.c
+++ b/src/rdm_downloadverapp.c
@@ -309,7 +309,7 @@ static INT32 rdmDwnlVAInstall(RDMAPPDetails *pRdmAppDet, CHAR **ppVer, INT32 num
         RDMInfo("Install the %s version of %s\n", pRdmAppDet->app_name, ppVer[i]);
         pRdmAppDet->app_dwnl_path[dlen] = 0;
         pRdmAppDet->app_home[hlen] = 0;
-	size_t app_dwnl_total_len = dlen + strlen("/v") + strlen(ppVer[i]) + 1; 
+	    size_t app_dwnl_total_len = dlen + strlen("/v") + strlen(ppVer[i]) + 1; 
         if (app_dwnl_total_len <= RDM_APP_PATH_LEN) {
             strcat(pRdmAppDet->app_dwnl_path, "/v");
             strcat(pRdmAppDet->app_dwnl_path, ppVer[i]);
@@ -317,7 +317,7 @@ static INT32 rdmDwnlVAInstall(RDMAPPDetails *pRdmAppDet, CHAR **ppVer, INT32 num
             RDMError("Version path exceeds buffer, skipping.\n");
             continue;
         } 
-	size_t needed_hlen = hlen + strlen("/v") + strlen(ppVer[i]) + strlen("/package") + 1; 
+	    size_t needed_hlen = hlen + strlen("/v") + strlen(ppVer[i]) + strlen("/package") + 1; 
         if (needed_hlen <= RDM_APP_PATH_LEN) {
             strcat(pRdmAppDet->app_home, "/v");
             strcat(pRdmAppDet->app_home, ppVer[i]);

--- a/src/rdm_downloadverapp.c
+++ b/src/rdm_downloadverapp.c
@@ -309,16 +309,16 @@ static INT32 rdmDwnlVAInstall(RDMAPPDetails *pRdmAppDet, CHAR **ppVer, INT32 num
         RDMInfo("Install the %s version of %s\n", pRdmAppDet->app_name, ppVer[i]);
         pRdmAppDet->app_dwnl_path[dlen] = 0;
         pRdmAppDet->app_home[hlen] = 0;
-	size_t app_dwnl_total_len = dlen + 2 + strlen(ppVer[i]); 
-        if (app_dwnl_total_len < RDM_APP_PATH_LEN) {
+	size_t app_dwnl_total_len = dlen + strlen("/v") + strlen(ppVer[i]) + 1; 
+        if (app_dwnl_total_len <= RDM_APP_PATH_LEN) {
             strcat(pRdmAppDet->app_dwnl_path, "/v");
             strcat(pRdmAppDet->app_dwnl_path, ppVer[i]);
         } else {
             RDMError("Version path exceeds buffer, skipping.\n");
             continue;
         } 
-	size_t needed_hlen = hlen + 2 + strlen(ppVer[i]) + 8; 
-        if (needed_hlen < RDM_APP_PATH_LEN) {
+	size_t needed_hlen = hlen + strlen("/v") + strlen(ppVer[i]) + strlen("/package") + 1; 
+        if (needed_hlen <= RDM_APP_PATH_LEN) {
             strcat(pRdmAppDet->app_home, "/v");
             strcat(pRdmAppDet->app_home, ppVer[i]);
             strcat(pRdmAppDet->app_home, "/package");


### PR DESCRIPTION
Reason for change: STRING OVERFLOW in rdm_downloadutils,rdm_downloadverapp and rdm_downloadutils
Test Procedure: Tested and verified
Risks: Low
Priority: P1
Signed-off-by: RoseMary_Benny@comcast.com