### PR TITLE
XIONE-18564:  RDK Download Manager Component Sync up with 8.4

### DIFF
--- a/src/rdm_downloadutils.c
+++ b/src/rdm_downloadutils.c
@@ -882,6 +882,10 @@ INT32 rdmUpdateAppDetails(RDMHandle *prdmHandle,
     if (ret != RDM_SUCCESS) {
         RDMWarn("Failed to Get RDM url from rbus\n");
         memset(pRdmAppDet->app_dwnl_url, 0, sizeof(pRdmAppDet->app_dwnl_url));
+	if (!pRdmAppDet || pRdmAppDet->app_dwnl_url[0] == '\0') {
+            RDMError("RFC is not Enabled for RDM_RFC_URL %s\n", RDM_RFC_URL);
+	}
+        return RDM_FAILURE;
     }
 
 
@@ -892,6 +896,8 @@ INT32 rdmUpdateAppDetails(RDMHandle *prdmHandle,
     if (ret != RDM_SUCCESS) {
         RDMWarn("Failed to Get mtls status from rbus\n");
         pRdmAppDet->is_mtls = 1;
+	RDMError("RFC is not Enabled for RDM_RFC_MTLS\n");
+	return RDM_FAILURE;
     }
 
 #ifdef RDM_ENABLE_CODEBIG


### PR DESCRIPTION
Reason for change: Update RDM with Latest Tag
Test Procedure: Build and check rdm downloads
Risks: Low