### PR TITLE
RDKEMW-17196 : /media/apps is getting printed in RDKB logs

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -64,6 +64,7 @@ if IS_RDKB
   rdm_SOURCES += src/rdm-cpc/rdm/rdm_openssl.c  \
                  src/rdm-cpc/rdm/rdm_downloadutils.c
   rdm_CFLAGS += -DRDM_ENABLE_CODEBIG \
+		-DIS_RDKB
               -I${top_srcdir}/src/rdm-cpc/rdm
   rdm_LDFLAGS += -lsecure_wrapper
 else

--- a/rdm_main.c
+++ b/rdm_main.c
@@ -260,6 +260,10 @@ int main(int argc, char* argv[])
     if(argc == 1) {
         RDMInfo("download all the apps mentioned in rdm-manifest.json file\n");
         download_all = 1;
+#ifdef IS_RDKB
+	is_broadband = 1;
+#endif
+
     }
     else {
         while ((opt_c = getopt (argc, argv, "a:u:v:x:hbo")) != -1) {


### PR DESCRIPTION
Reason for change: /media/apps is getting printed in RDKB logs
Test Procedure: Tested and verified
Risks: Low
Priority: P1
Signed-off-by: RoseMary_Benny@comcast.com