### PR TITLE
RDKEMW-18326: [support/8.4.4.0]Observed rdm crash with fingerprint 27926612 and memset function

### DIFF
--- a/src/rdm_download.c
+++ b/src/rdm_download.c
@@ -105,7 +105,6 @@ INT32 rdmDownloadApp(RDMAPPDetails *pRdmAppDet, INT32 *pDLStatus)
     CHAR *DLInfoPath = NULL;
     CHAR *DLInfoFile = NULL;
     INT32 DLInfoStatus = RDM_SUCCESS;
-    FILE  *fp_met = NULL;
 
     *pDLStatus = RDM_DL_NOERROR;
 

--- a/src/rdm_download.c
+++ b/src/rdm_download.c
@@ -184,7 +184,7 @@ INT32 rdmDownloadApp(RDMAPPDetails *pRdmAppDet, INT32 *pDLStatus)
 
     /*If the rdmDownloadInfo.txt file doesn't exist, it will be created*/
     if(DLInfoStatus == RDM_SUCCESS) {
-        char tmpfile[512];
+        char tmpfile[RDM_APP_PATH_LEN + 5];
         snprintf(tmpfile, sizeof(tmpfile), "%s.tmp", pRdmAppDet->app_dwnl_info);
         FILE *fp_in = fopen(pRdmAppDet->app_dwnl_info, "r");
         FILE *fp_out = fopen(tmpfile, "w");
@@ -210,6 +210,7 @@ INT32 rdmDownloadApp(RDMAPPDetails *pRdmAppDet, INT32 *pDLStatus)
             // Atomically replace the original file
             if (rename(tmpfile, pRdmAppDet->app_dwnl_info) != 0) {
                 RDMError("Failed to rename temp file to %s\n", pRdmAppDet->app_dwnl_info);
+		remove(tmpfile);
             } else {
                 RDMInfo("Meta data file updated successfully\n");
             }

--- a/src/rdm_download.c
+++ b/src/rdm_download.c
@@ -185,41 +185,38 @@ INT32 rdmDownloadApp(RDMAPPDetails *pRdmAppDet, INT32 *pDLStatus)
 
     /*If the rdmDownloadInfo.txt file doesn't exist, it will be created*/
     if(DLInfoStatus == RDM_SUCCESS) {
-        fp_met = fopen(pRdmAppDet->app_dwnl_info, "a+");
-        if(fp_met) {
-            char buffer[4096]={0};
+        char tmpfile[512];
+        snprintf(tmpfile, sizeof(tmpfile), "%s.tmp", pRdmAppDet->app_dwnl_info);
+        FILE *fp_in = fopen(pRdmAppDet->app_dwnl_info, "r");
+        FILE *fp_out = fopen(tmpfile, "w");
+        if (fp_out) {
             char line[256];
-            size_t buffer_index = 0;
-
-            RDMInfo("Opened %s file successfully\n", pRdmAppDet->app_dwnl_info);
-            fseek(fp_met, 0, SEEK_SET);
-            while (fgets(line, sizeof(line), fp_met)) {
-                if(strncmp(line, pRdmAppDet->app_name, strlen(pRdmAppDet->app_name)) != 0 ){
-                    int buflen = snprintf(buffer + buffer_index, sizeof(buffer) - buffer_index, "%s", line);
-                    if (buflen < 0 || (size_t)buflen >= (sizeof(buffer) - buffer_index)) {
-                        RDMWarn("Buffer Overflow\n");
-                        break;
+            if (fp_in) {
+                while (fgets(line, sizeof(line), fp_in)) {
+                    if (strncmp(line, pRdmAppDet->app_name, strlen(pRdmAppDet->app_name)) != 0) {
+                        fputs(line, fp_out);
                     }
-                    buffer_index += buflen;
                 }
+                fclose(fp_in);
             }
-
-            ftruncate(fileno(fp_met), 0);
-            fseek(fp_met, 0, SEEK_SET);
-
-            fputs(buffer, fp_met);
-
-            fseek(fp_met, 0, SEEK_END);
-            fprintf(fp_met, "%s %s %s/%s %d %s\n", pRdmAppDet->app_name,
-                                                   pRdmAppDet->pkg_name,
-                                                   pRdmAppDet->app_home,
-                                                   pRdmAppDet->app_name,
-                                                   pRdmAppDet->app_size_kb,
-                                                   rdm_status);
-            fclose(fp_met);
-        }
-        else {
-            RDMWarn("Unable to open meta data file: %s\n", pRdmAppDet->app_dwnl_info);
+            // Append the new entry
+            fprintf(fp_out, "%s %s %s/%s %d %s\n",
+                pRdmAppDet->app_name,
+                pRdmAppDet->pkg_name,
+                pRdmAppDet->app_home,
+                pRdmAppDet->app_name,
+                pRdmAppDet->app_size_kb,
+                rdm_status);
+            fclose(fp_out);
+            // Atomically replace the original file
+            if (rename(tmpfile, pRdmAppDet->app_dwnl_info) != 0) {
+                RDMError("Failed to rename temp file to %s\n", pRdmAppDet->app_dwnl_info);
+            } else {
+                RDMInfo("Meta data file updated successfully\n");
+            }
+        } else {
+            RDMWarn("Unable to open temp meta data file: %s\n", tmpfile);
+            if (fp_in) fclose(fp_in);
         }
     }
     else{


### PR DESCRIPTION
Reason for change : Fix for Buffer Overflow
